### PR TITLE
BAT-288: removed req for git tag to publish Debian in do/publish

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
       - "do/package"
     key: "package"
     artifact_paths:
-      - "build-output/CyUSBSerial-*-Linux.deb"
+      - "build-output/*.deb"
     timeout_in_minutes: ${DEFAULT_TIMEOUT}
     retry:
       automatic:
@@ -45,6 +45,8 @@ steps:
       automatic:
         - exit_status: 1
           limit: 2
+    soft_fail:
+      - exit_status: 123
 
   - label: ":rocket: Test Results"
     plugins:

--- a/do/publish
+++ b/do/publish
@@ -65,8 +65,9 @@ function publish_deb()
 
   # make sure the Debian file doesn't already exist on the S3 bucket
   if [[ -n $( aws --region "${AWS_REGION}" s3 ls "${APT_REPOSITORY_URI}/${debian}" ) ]]; then
-    echo "ERROR: Cannot publish Debian.  File already exists in APT Repo (${APT_REPOSITORY_URI})." >&2
-    exit 1
+    echo "ERROR: Cannot publish ${debian}.  File already exists in APT Repo (${APT_REPOSITORY_URI})." >&2
+    # Specifically using a unique error code so we can soft fail in the pipeline when develop is re-run.
+    exit 123
   fi
 
   echo "Pushing '${debian}' to ${APT_REPOSITORY_URI}"

--- a/do/publish
+++ b/do/publish
@@ -32,12 +32,6 @@ function publish_deb()
 {
   echo "--- :debian: Publish Debian file to APT Repo"
 
-  # make sure a git tag exists
-  if [[ -z "${GIT_VER_TAG-}" ]]; then
-    echo "No version tag on repo.  Nothing to do. Exiting early."
-    exit 0
-  fi
-
   # determine if there are uncommitted changes to tracked files
   if [[ -n $( git status --porcelain --untracked-files=no ) ]];  then
     echo "ERROR: Cannot publish Debian due to local changes to tracked files." >&2


### PR DESCRIPTION
[BAT-288](https://pathrobotics.atlassian.net/browse/BAT-288?atlOrigin=eyJpIjoiYjIwOGJiNTc0NDM2NDRkZDhhMmE5ZWFmMjEzMWIzNzQiLCJwIjoiaiJ9)

Removed the check for a git tag when publishing the Debian package in `do/publish`