### PR TITLE
Update to use us-east-2 by default for do/ scripts

### DIFF
--- a/do/private/script_utils.sh
+++ b/do/private/script_utils.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034
 # Disable unused variable check for configure_environment function
 
-DEFAULT_AWS_REGION="us-east-1"
+DEFAULT_AWS_REGION="us-east-2"
 
 function show_stack() {
   local frame=0


### PR DESCRIPTION
[BAT-304](https://pathrobotics.atlassian.net/browse/BAT-304)

In order to be ready to stop using CodeBuild, the do/ scripts need to reference `us-east-2` by default.  